### PR TITLE
gemspec update.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ PLATFORMS
   arm64-darwin-23
 
 DEPENDENCIES
-  bundler
+  bundler (>= 2.5)
   concurrent-ruby (~> 1.1)
   descope!
   factory_bot (= 6.4.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,9 +37,6 @@ GEM
       activesupport (>= 5.0.0)
     faker (3.2.3)
       i18n (>= 1.8.11, < 2)
-    fuubar (2.5.1)
-      rspec-core (~> 3.0)
-      ruby-progressbar (~> 1.4)
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
@@ -68,7 +65,6 @@ GEM
     rack-test (2.1.0)
       rack (>= 1.3)
     rainbow (3.1.1)
-    rake (13.1.0)
     regexp_parser (2.9.0)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
@@ -136,14 +132,10 @@ PLATFORMS
   arm64-darwin-23
 
 DEPENDENCIES
-  bundler (>= 2.5)
-  concurrent-ruby (~> 1.1)
   descope!
   factory_bot (= 6.4.6)
   faker
-  fuubar (~> 2.0)
   rack-test (= 2.1.0)
-  rake (~> 13.0)
   rotp (= 6.3.0)
   rspec (= 3.13.0)
   rubocop (= 1.60.2)

--- a/descope.gemspec
+++ b/descope.gemspec
@@ -1,11 +1,12 @@
 # -*- encoding: utf-8 -*-
 $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 require 'descope/version'
+version = Descope::VERSION
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "descope"
-  s.version     = Descope::VERSION
+  s.version     = version
   s.summary     = "Descope Ruby API Client"
   s.description = "Ruby API Client for Descope API https://descope.com"
 
@@ -25,10 +26,9 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     "bug_tracker_uri"   => "https://github.com/descope/descope-ruby-sdk/issues",
-    "changelog_uri"     => "https://github.com/descope/descope-ruby-sdk/releases/tag/v#{version}",
+    "changelog_uri"     => "https://github.com/descope/descope-ruby-sdk/releases/tag/#{version}",
     "documentation_uri" => "https://docs.descope.com",
     "source_code_uri" => "https://github.com/descope/descope-ruby-sdk/tree/#{version}",
-    "rubygems_mfa_required" => 'true',
   }
 
   s.add_runtime_dependency 'rest-client', '~> 2.1'

--- a/descope.gemspec
+++ b/descope.gemspec
@@ -3,18 +3,33 @@ $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 require 'descope/version'
 
 Gem::Specification.new do |s|
-  s.name        = 'descope'
+  s.platform    = Gem::Platform::RUBY
+  s.name        = "descope"
   s.version     = Descope::VERSION
-  s.authors     = ['Descope']
-  s.email       = ['support@descope.com']
-  s.homepage    = 'https://github.com/descope/descope-ruby-sdk'
-  s.summary     = 'Descope API Client'
-  s.description = 'Ruby API Client for Descope API https://descope.com'
+  s.summary     = "Descope Ruby API Client"
+  s.description = "Ruby API Client for Descope API https://descope.com"
+
+  s.required_ruby_version     = ">= 3.3.0"
+  s.required_rubygems_version = ">= 3.5.6"
+
+  s.author      = "Descope Inc."
+  s.email       = "support@descope.com"
+  s.homepage    = "https://github.com/descope/descope-ruby-sdk"
+
+  s.license = "MIT"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
+
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/descope/descope-ruby-sdk/issues",
+    "changelog_uri"     => "https://github.com/descope/descope-ruby-sdk/releases/tag/v#{version}",
+    "documentation_uri" => "https://docs.descope.com",
+    "source_code_uri" => "https://github.com/descope/descope-ruby-sdk/tree/#{version}",
+    "rubygems_mfa_required" => 'true',
+  }
 
   s.add_runtime_dependency 'rest-client', '~> 2.1'
   s.add_runtime_dependency 'jwt', '~> 2.7'
@@ -22,13 +37,12 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'addressable', '~> 2.8'
   s.add_runtime_dependency 'retryable', '~> 3.0'
 
-  s.add_development_dependency 'bundler'
+  s.add_development_dependency 'bundler', '>= 2.5'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'fuubar', '~> 2.0'
   s.add_development_dependency 'rspec', '~> 3.11'
   s.add_development_dependency 'simplecov', '~> 0.9'
   s.add_development_dependency 'faker', '~> 2.0'
-  s.add_development_dependency "super_diff", "~> 1.0"
+  s.add_development_dependency 'super_diff', '~> 1.0'
   s.add_development_dependency 'concurrent-ruby', '~> 1.1'
-  s.license = 'MIT'
 end

--- a/descope.gemspec
+++ b/descope.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description = "Ruby API Client for Descope API https://descope.com"
 
   s.required_ruby_version     = ">= 3.3.0"
-  s.required_rubygems_version = ">= 3.5.6"
+  s.required_rubygems_version = ">= 3.5"
 
   s.author      = "Descope Inc."
   s.email       = "support@descope.com"
@@ -31,18 +31,9 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/descope/descope-ruby-sdk/tree/#{version}",
   }
 
-  s.add_runtime_dependency 'rest-client', '~> 2.1'
-  s.add_runtime_dependency 'jwt', '~> 2.7'
-  s.add_runtime_dependency 'zache', '~> 0.12'
   s.add_runtime_dependency 'addressable', '~> 2.8'
+  s.add_runtime_dependency 'jwt', '~> 2.7'
+  s.add_runtime_dependency 'rest-client', '~> 2.1'
   s.add_runtime_dependency 'retryable', '~> 3.0'
-
-  s.add_development_dependency 'bundler', '>= 2.5'
-  s.add_development_dependency 'rake', '~> 13.0'
-  s.add_development_dependency 'fuubar', '~> 2.0'
-  s.add_development_dependency 'rspec', '~> 3.11'
-  s.add_development_dependency 'simplecov', '~> 0.9'
-  s.add_development_dependency 'faker', '~> 2.0'
-  s.add_development_dependency 'super_diff', '~> 1.0'
-  s.add_development_dependency 'concurrent-ruby', '~> 1.1'
+  s.add_runtime_dependency 'zache', '~> 0.12'
 end


### PR DESCRIPTION
## Description

Update gemspec for missing information on RubyGems.org

currently looks like this
![image](https://github.com/descope/descope-ruby-sdk/assets/130996527/9e57942d-f260-4959-a72a-e7ea0539f604)

missing links to the correct version tag, issues, and docs