### PR TITLE
Add invite user template

### DIFF
--- a/lib/descope/api/v1/management/user.rb
+++ b/lib/descope/api/v1/management/user.rb
@@ -611,7 +611,8 @@ module Descope
             middle_name: nil,
             family_name: nil,
             sso_app_ids: [],
-            skip_create: false
+            skip_create: false,
+            template_id: nil
           )
             role_names ||= []
             user_tenants ||= []
@@ -641,7 +642,8 @@ module Descope
               additional_identifiers:,
               password:,
               hashed_password:,
-              sso_app_ids:
+              sso_app_ids:,
+              template_id:,
             )
             return request_params if skip_create
 
@@ -670,7 +672,8 @@ module Descope
             additional_identifiers: [],
             password: nil,
             hashed_password: {},
-            sso_app_ids: []
+            sso_app_ids: [],
+            template_id: nil
           )
             body = user_compose_update_body(
               login_id:,
@@ -689,7 +692,8 @@ module Descope
               additional_identifiers:,
               password:,
               hashed_password:,
-              sso_app_ids:
+              sso_app_ids:,
+              template_id:,
             )
             body[:invite] = invite
             body[:verifiedEmail] = verified_email unless verified_email.nil? || verified_email.empty?
@@ -720,7 +724,8 @@ module Descope
             additional_identifiers: [],
             password: nil,
             hashed_password: {},
-            sso_app_ids: []
+            sso_app_ids: [],
+            template_id: nil
           )
             body = {
               loginId: login_id,
@@ -759,6 +764,7 @@ module Descope
             body[:middleName] = middle_name unless middle_name.nil?
             body[:familyName] = family_name unless family_name.nil?
             body[:verifiedPhone] = verified_phone unless verified_phone.nil?
+            body[:templateId] = template_id unless template_id.nil? || template_id.empty?
             body
           end
         end

--- a/spec/lib.descope/api/v1/management/user_spec.rb
+++ b/spec/lib.descope/api/v1/management/user_spec.rb
@@ -122,14 +122,16 @@ describe Descope::Api::V1::Management::User do
           loginId: 'name@mail.com',
           email: 'name@mail.com',
           test: false,
-          invite: true
+          invite: true,
+          templateId: "tid",
         }
       )
 
       expect do
         @instance.invite_user(
           login_id: 'name@mail.com',
-          email: 'name@mail.com'
+          email: 'name@mail.com',
+          template_id: "tid",
         )
       end.not_to raise_error
     end


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/11205

This pull request introduces support for a new `template_id` parameter in user management methods, enhancing the flexibility of user creation and updates. The changes primarily involve updating method signatures and request bodies to include this new parameter, along with corresponding test updates.

### Enhancements to user management methods:

* [`lib/descope/api/v1/management/user.rb`](diffhunk://#diff-0b2b860f7625ce3bb944355f5d8cf175f97b4a8884cfe5d01f0738ca430cf784L614-R615): Added the `template_id` parameter to the `user_create`, `user_compose_create_body`, and `user_compose_update_body` methods, ensuring it is passed through and included in the request payload when provided. 

### Test updates:

* [`spec/lib.descope/api/v1/management/user_spec.rb`](diffhunk://#diff-bf6e37f8b5b78ffcc41036daf3243e6f48047b9ba6d7dd0bf0af71cc380c9243L125-R134): Updated tests to include `template_id` in the input and verify its presence in the generated request payload.