### PR TITLE
chore: modify release-please workflow permissions and token

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -6,19 +6,25 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          private_key: ${{ secrets.RELEASE_APP_PEM }}
+          app_id: ${{ secrets.RELEASE_APP_ID }}
+
       - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
         id: release
         with:
           # The release-please-config.json and .release-please-manifest.json files
           # are automatically detected in the root of the repository
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.get_token.outputs.token }}
 
       - name: Show outputs
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Updated GitHub Actions workflow to change permissions and use a GitHub App token for releases.

## Related Issues

Fixes <link_to_github_issue>

## Related PRs

| branch       | PR         |
| ------------ | ---------- |
| service a PR | Link to PR |
| service b PR | Link to PR |

## Description

A few sentences describing the overall goals of the pull request's commits.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
