### PR TITLE
feat: [Ruby] Add created/modified time search params to search_all_users()

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,7 +644,9 @@ descope_client.logout_user('<login-id>')
 descope_client.logout_user_by_id('<user-id>')
 
 # Search all users, optionally according to tenant and/or role filter
-# results can be paginated using the limit and page parameters
+# results can be paginated using the limit and page parameters,
+# as well as filtered by time with from_created_time, to_created_time,
+# from_modified_time, and to_modified_time (Unix epoch milliseconds)
 users_resp = descope_client.search_all_users(tenant_ids = ['my-tenant-id'])
 users = users_resp['users']
 users.each do |user|

--- a/lib/descope/api/v1/management/user.rb
+++ b/lib/descope/api/v1/management/user.rb
@@ -171,6 +171,10 @@ module Descope
 
           # Search for users, using a valid management key.
           # @see https://docs.descope.com/api/openapi/usermanagement/operation/SearchUsers/
+          # @param from_created_time [Integer, nil] only include users created on or after this time (Unix epoch milliseconds).
+          # @param to_created_time [Integer, nil] only include users created on or before this time (Unix epoch milliseconds).
+          # @param from_modified_time [Integer, nil] only include users modified on or after this time (Unix epoch milliseconds).
+          # @param to_modified_time [Integer, nil] only include users modified on or before this time (Unix epoch milliseconds).
           def search_all_users(
             login_id: nil,
             tenant_ids: [],
@@ -187,7 +191,11 @@ module Descope
             phones: [],
             sso_app_ids: [],
             tenant_role_ids: {},
-            tenant_role_names: {}
+            tenant_role_names: {},
+            from_created_time: nil,
+            to_created_time: nil,
+            from_modified_time: nil,
+            to_modified_time: nil
           )
             body = {
               loginId: login_id,
@@ -216,6 +224,10 @@ module Descope
             body[:roleNames] = role_names unless role_names.empty?
             body[:tenantRoleIds] = map_to_values_object(tenant_role_ids) unless tenant_role_ids.nil? || tenant_role_ids.empty?
             body[:tenantRoleNames] = map_to_values_object(tenant_role_names) unless tenant_role_names.nil? || tenant_role_names.empty?
+            body[:fromCreatedTime] = from_created_time unless from_created_time.nil?
+            body[:toCreatedTime] = to_created_time unless to_created_time.nil?
+            body[:fromModifiedTime] = from_modified_time unless from_modified_time.nil?
+            body[:toModifiedTime] = to_modified_time unless to_modified_time.nil?
             post(Common::USERS_SEARCH_PATH, body)
           end
 
@@ -530,6 +542,10 @@ module Descope
           # @param text [String] Optional string, allows free text search among all user's attributes.
           # @param login_ids [Array<String>] Optional list of login ids
           # @param sort [Array<Hash>] Optional array, allows to sort by fields.
+          # @param from_created_time [Integer, nil] Optional, only include users created on or after this time (Unix epoch milliseconds).
+          # @param to_created_time [Integer, nil] Optional, only include users created on or before this time (Unix epoch milliseconds).
+          # @param from_modified_time [Integer, nil] Optional, only include users modified on or after this time (Unix epoch milliseconds).
+          # @param to_modified_time [Integer, nil] Optional, only include users modified on or before this time (Unix epoch milliseconds).
           #
           # @return [Hash] Return hash in the format {"users": []}
           #
@@ -551,7 +567,11 @@ module Descope
             text: nil,
             login_ids: [],
             tenant_role_ids: {},
-            tenant_role_names: {}
+            tenant_role_names: {},
+            from_created_time: nil,
+            to_created_time: nil,
+            from_modified_time: nil,
+            to_modified_time: nil
           )
             tenant_ids ||= []
             role_names ||= []
@@ -581,6 +601,10 @@ module Descope
             body[:text] = text unless text.nil? || text.empty?
             body[:tenantRoleIds] = map_to_values_object(tenant_role_ids) unless tenant_role_ids.nil? || tenant_role_ids.empty?
             body[:tenantRoleNames] = map_to_values_object(tenant_role_names) unless tenant_role_names.nil? || tenant_role_names.empty?
+            body[:fromCreatedTime] = from_created_time unless from_created_time.nil?
+            body[:toCreatedTime] = to_created_time unless to_created_time.nil?
+            body[:fromModifiedTime] = from_modified_time unless from_modified_time.nil?
+            body[:toModifiedTime] = to_modified_time unless to_modified_time.nil?
 
             post(Common::TEST_USERS_SEARCH_PATH, body)
           end

--- a/lib/descope/api/v1/management/user.rb
+++ b/lib/descope/api/v1/management/user.rb
@@ -171,9 +171,9 @@ module Descope
 
           # Search for users, using a valid management key.
           # @see https://docs.descope.com/api/openapi/usermanagement/operation/SearchUsers/
-          # @param from_created_time [Integer, nil] only include users created on or after this time (Unix epoch milliseconds).
+          # @param from_created_time [Integer, nil] only include users created after this time (Unix epoch milliseconds).
           # @param to_created_time [Integer, nil] only include users created on or before this time (Unix epoch milliseconds).
-          # @param from_modified_time [Integer, nil] only include users modified on or after this time (Unix epoch milliseconds).
+          # @param from_modified_time [Integer, nil] only include users modified after this time (Unix epoch milliseconds).
           # @param to_modified_time [Integer, nil] only include users modified on or before this time (Unix epoch milliseconds).
           def search_all_users(
             login_id: nil,
@@ -542,9 +542,9 @@ module Descope
           # @param text [String] Optional string, allows free text search among all user's attributes.
           # @param login_ids [Array<String>] Optional list of login ids
           # @param sort [Array<Hash>] Optional array, allows to sort by fields.
-          # @param from_created_time [Integer, nil] Optional, only include users created on or after this time (Unix epoch milliseconds).
+          # @param from_created_time [Integer, nil] Optional, only include users created after this time (Unix epoch milliseconds).
           # @param to_created_time [Integer, nil] Optional, only include users created on or before this time (Unix epoch milliseconds).
-          # @param from_modified_time [Integer, nil] Optional, only include users modified on or after this time (Unix epoch milliseconds).
+          # @param from_modified_time [Integer, nil] Optional, only include users modified after this time (Unix epoch milliseconds).
           # @param to_modified_time [Integer, nil] Optional, only include users modified on or before this time (Unix epoch milliseconds).
           #
           # @return [Hash] Return hash in the format {"users": []}

--- a/spec/lib.descope/api/v1/management/user_spec.rb
+++ b/spec/lib.descope/api/v1/management/user_spec.rb
@@ -287,6 +287,7 @@ describe Descope::Api::V1::Management::User do
           roleNames: [],
           limit: 0,
           page: 0,
+          text: nil,
           ssoAppIds: [],
           ssoOnly: false,
           testUsersOnly: false,

--- a/spec/lib.descope/api/v1/management/user_spec.rb
+++ b/spec/lib.descope/api/v1/management/user_spec.rb
@@ -278,6 +278,35 @@ describe Descope::Api::V1::Management::User do
         )
       end.not_to raise_error
     end
+
+    it 'is expected to include time-range filters when provided' do
+      expect(@instance).to receive(:post).with(
+        USERS_SEARCH_PATH, {
+          loginId: nil,
+          tenantIds: [],
+          roleNames: [],
+          limit: 0,
+          page: 0,
+          ssoAppIds: [],
+          ssoOnly: false,
+          testUsersOnly: false,
+          withTestUser: false,
+          fromCreatedTime: 1_700_000_000_000,
+          toCreatedTime: 1_800_000_000_000,
+          fromModifiedTime: 1_700_000_000_000,
+          toModifiedTime: 1_800_000_000_000
+        }
+      )
+
+      expect do
+        @instance.search_all_users(
+          from_created_time: 1_700_000_000_000,
+          to_created_time: 1_800_000_000_000,
+          from_modified_time: 1_700_000_000_000,
+          to_modified_time: 1_800_000_000_000
+        )
+      end.not_to raise_error
+    end
   end
 
   context '.get_provider_token' do
@@ -788,6 +817,32 @@ describe Descope::Api::V1::Management::User do
           role_names: %w[r1 r2],
           tenant_role_ids: tenant_role_ids,
           tenant_role_names: tenant_role_names
+        )
+      end.not_to raise_error
+    end
+
+    it 'is expected to include time-range filters when provided' do
+      expect(@instance).to receive(:post).with(
+        TEST_USERS_SEARCH_PATH, {
+          tenantIds: [],
+          roleNames: [],
+          limit: 0,
+          page: 0,
+          testUsersOnly: true,
+          withTestUser: true,
+          fromCreatedTime: 1_700_000_000_000,
+          toCreatedTime: 1_800_000_000_000,
+          fromModifiedTime: 1_700_000_000_000,
+          toModifiedTime: 1_800_000_000_000
+        }
+      )
+
+      expect do
+        @instance.search_all_test_users(
+          from_created_time: 1_700_000_000_000,
+          to_created_time: 1_800_000_000_000,
+          from_modified_time: 1_700_000_000_000,
+          to_modified_time: 1_800_000_000_000
         )
       end.not_to raise_error
     end


### PR DESCRIPTION
Fixes descope/etc#9538

## What
Adds time-based filtering to the Ruby SDK's user search API. This closes the last gap identified in #9538 for this SDK.

The user search API now supports:
- `from_created_time` / `to_created_time`: filter users by when they were created (Unix epoch milliseconds)
- `from_modified_time` / `to_modified_time`: filter users by when they were last modified (Unix epoch milliseconds)

Note on how the bounds work: `from_created_time` and `from_modified_time` are exclusive (strictly after the given time), while `to_created_time` and `to_modified_time` are inclusive (on or before the given time). This matches how the backend actually compares these values.

## Implementation Details
- Added `from_created_time`, `to_created_time`, `from_modified_time`, and `to_modified_time` as new optional keyword arguments to `search_all_users()` and `search_all_test_users()` in `lib/descope/api/v1/management/user.rb`, following the same pattern already used for the other optional params in these methods.
- Added YARD `@param` docs for all 4 new params on both methods.
- Corrected the wording on `from_created_time` and `from_modified_time` from "on or after" to "after", after tracing the actual backend comparison logic in managementservice.
- Added two new RSpec tests covering both methods, matching the existing test style in `spec/lib.descope/api/v1/management/user_spec.rb`.
- Updated the README's "Search all users" example to mention the new time-filter params.

## Verification
- Ran the full test suite with Ruby 3.3+: 46 examples, 0 failures, including both new tests.
- Verified against a live Descope project using the repo's own sample app (`examples/ruby/management/user_app.rb`), temporarily pointed at this local branch. Confirmed that `from_created_time` correctly includes users created within the window, and correctly excludes everyone when the bound is set to an impossible future date. The temporary changes were reverted afterward and aren't part of this PR.

## Notes
- This is one of 4 coordinated PRs for #9538. Companion PRs: [descope-php#133](https://github.com/descope/descope-php/pull/133), [go-sdk#822](https://github.com/descope/go-sdk/pull/822), [node-sdk#786](https://github.com/descope/node-sdk/pull/786).
- Scope was limited to `search_all_users()` and `search_all_test_users()`. No other functionality in `user.rb` was touched.
