### PR TITLE
feat(enchantedlink): add SMS support alongside the existing email routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,33 @@ pending_ref = res['pendingRef'] # Used to poll for a valid session
 masked_email = res['maskedEmail'] # The email that the message was sent to in a masked format
 ```
 
+The same three calls are available over SMS, as `enchanted_link_sign_up_with_phone`,
+`enchanted_link_sign_in_with_phone` and `enchanted_link_sign_up_or_in_with_phone`. The `login_id` is
+a phone number, and the response carries `maskedPhone` instead of `maskedEmail`.
+
+```ruby
+res = descope_client.enchanted_link_sign_up_or_in_with_phone(
+    login_id: '+11111111111',
+    uri: 'https://myapp.com/verify-enchanted-link', # Set redirect URI here or via console
+    template_id: 'my-text-template-id' # Optional, selects a specific text template
+)
+link_identifier = res['linkId'] # Show the user which link they should press in their SMS
+pending_ref = res['pendingRef'] # Used to poll for a valid session
+masked_phone = res['maskedPhone'] # The phone number that the message was sent to in a masked format
+```
+
+An existing user's phone number can be updated with an enchanted link sent over SMS, using the
+refresh token of their active session:
+
+```ruby
+res = descope_client.enchanted_link_update_user_phone(
+    login_id: 'someone@example.com',
+    phone: '+11111111111',
+    uri: 'https://myapp.com/verify-enchanted-link',
+    refresh_token: refresh_token
+)
+```
+
 After sending the link, you must poll to receive a valid session using the `pending_ref` from
 the previous step. A valid session will be returned only after the user clicks the right link.
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ res = descope_client.enchanted_link_sign_up_or_in_with_phone(
     uri: 'https://myapp.com/verify-enchanted-link', # Set redirect URI here or via console
     template_id: 'my-text-template-id' # Optional, selects a specific text template
 )
-link_identifier = res['linkId'] # Show the user which link they should press in their SMS
+link_identifier = res['linkId'] # Matches the identifier at the start of the SMS, so the user can confirm it
 pending_ref = res['pendingRef'] # Used to poll for a valid session
 masked_phone = res['maskedPhone'] # The phone number that the message was sent to in a masked format
 ```

--- a/lib/descope/api/v1/auth/enchantedlink.rb
+++ b/lib/descope/api/v1/auth/enchantedlink.rb
@@ -20,6 +20,16 @@ module Descope
             post(uri, body, {}, refresh_token)
           end
 
+          def enchanted_link_sign_in_with_phone(login_id: nil, uri: nil, login_options: nil, provider_id: nil, template_id: nil, refresh_token: nil)
+            validate_login_id(login_id)
+            validate_refresh_token_provided(login_options, refresh_token)
+            body = enchanted_link_compose_signin_body(login_id, uri, login_options)
+            body[:providerId] = provider_id if provider_id
+            body[:templateId] = template_id if template_id
+            uri = enchanted_link_compose_signin_url(Descope::Mixins::Common::DeliveryMethod::SMS)
+            post(uri, body, {}, refresh_token)
+          end
+
           def enchanted_link_sign_up(login_id: nil, uri: nil, user: {})
             # Sign-up new end user by sending an enchanted link via email
             # @see https://docs.descope.com/api/openapi/enchantedlink/operation/SignUpEnchantedLink/
@@ -36,10 +46,35 @@ module Descope
             post(uri, body)
           end
 
+          def enchanted_link_sign_up_with_phone(login_id: nil, uri: nil, user: {}, provider_id: nil, template_id: nil)
+            method = Descope::Mixins::Common::DeliveryMethod::SMS
+
+            unless adjust_and_verify_delivery_method(method, login_id, user)
+              raise Descope::ArgumentException.new(
+                'Invalid delivery method',
+                code: 400
+              )
+            end
+
+            body = enchanted_link_compose_signup_body(login_id, uri, user, method)
+            body[:providerId] = provider_id if provider_id
+            body[:templateId] = template_id if template_id
+            uri = enchanted_link_compose_signup_url(method)
+            post(uri, body)
+          end
+
           def enchanted_link_sign_up_or_in(login_id: nil, uri: nil, login_options: nil)
             # @see https://docs.descope.com/api/openapi/enchantedlink/operation/SignUpOrInEnchantedLinkEmail/
             body = enchanted_link_compose_signin_body(login_id, uri, login_options)
             uri = enchanted_link_compose_sign_up_or_in_url
+            post(uri, body)
+          end
+
+          def enchanted_link_sign_up_or_in_with_phone(login_id: nil, uri: nil, login_options: nil, provider_id: nil, template_id: nil)
+            body = enchanted_link_compose_signin_body(login_id, uri, login_options)
+            body[:providerId] = provider_id if provider_id
+            body[:templateId] = template_id if template_id
+            uri = enchanted_link_compose_sign_up_or_in_url(Descope::Mixins::Common::DeliveryMethod::SMS)
             post(uri, body)
           end
 
@@ -56,6 +91,22 @@ module Descope
             body[:templateId] = template_id if template_id
             body[:templateOptions] = template_options if template_options
             uri = UPDATE_USER_EMAIL_ENCHANTEDLINK_PATH
+            post(uri, body, {}, refresh_token)
+          end
+
+          def enchanted_link_update_user_phone(login_id: nil, phone: nil, uri: nil, add_to_login_ids: nil, on_merge_use_existing: nil, provider_id: nil, template_id: nil, template_options: nil, refresh_token: nil)
+            validate_login_id(login_id)
+            validate_token_not_empty(refresh_token)
+            validate_phone(Descope::Mixins::Common::DeliveryMethod::SMS, phone)
+
+            body = enchanted_link_compose_update_user_phone_body(
+              login_id, phone, add_to_login_ids, on_merge_use_existing
+            )
+            body[:redirectUrl] = uri
+            body[:providerId] = provider_id if provider_id
+            body[:templateId] = template_id if template_id
+            body[:templateOptions] = template_options if template_options
+            uri = compose_url(UPDATE_USER_PHONE_ENCHANTEDLINK_PATH, Descope::Mixins::Common::DeliveryMethod::SMS)
             post(uri, body, {}, refresh_token)
           end
 
@@ -97,19 +148,23 @@ module Descope
             body
           end
 
-          def enchanted_link_compose_signin_url
-            compose_url(SIGN_IN_AUTH_ENCHANTEDLINK_PATH, Descope::Mixins::Common::DeliveryMethod::EMAIL)
+          def enchanted_link_compose_signin_url(method = nil)
+            method = Descope::Mixins::Common::DeliveryMethod::EMAIL if method.nil?
+            compose_url(SIGN_IN_AUTH_ENCHANTEDLINK_PATH, method)
           end
 
-          def enchanted_link_compose_signup_url
-            compose_url(SIGN_UP_AUTH_ENCHANTEDLINK_PATH, Descope::Mixins::Common::DeliveryMethod::EMAIL)
+          def enchanted_link_compose_signup_url(method = nil)
+            method = Descope::Mixins::Common::DeliveryMethod::EMAIL if method.nil?
+            compose_url(SIGN_UP_AUTH_ENCHANTEDLINK_PATH, method)
           end
 
-          def enchanted_link_compose_sign_up_or_in_url
-            compose_url(SIGN_UP_OR_IN_AUTH_ENCHANTEDLINK_PATH, Descope::Mixins::Common::DeliveryMethod::EMAIL)
+          def enchanted_link_compose_sign_up_or_in_url(method = nil)
+            method = Descope::Mixins::Common::DeliveryMethod::EMAIL if method.nil?
+            compose_url(SIGN_UP_OR_IN_AUTH_ENCHANTEDLINK_PATH, method)
           end
 
-          def enchanted_link_compose_signup_body(login_id, uri, user)
+          def enchanted_link_compose_signup_body(login_id, uri, user, method = nil)
+            method = Descope::Mixins::Common::DeliveryMethod::EMAIL if method.nil?
             body = {
               loginId: login_id,
               redirectUrl: uri
@@ -118,7 +173,7 @@ module Descope
             unless user.nil? || user.empty?
               body[:user] = enchantedlink_user_compose_update_body(**user) unless user.empty?
 
-              method_str, val = get_login_id_by_method(method: Descope::Mixins::Common::DeliveryMethod::EMAIL, user:)
+              method_str, val = get_login_id_by_method(method:, user:)
               body[method_str.to_sym] = val
             end
 
@@ -132,6 +187,18 @@ module Descope
             }
 
             body[:addToLoginIds] = add_to_login_ids if add_to_login_ids
+            body[:onMergeUseExisting] = on_merge_use_existing if on_merge_use_existing
+
+            body
+          end
+
+          def enchanted_link_compose_update_user_phone_body(login_id, phone, add_to_login_ids, on_merge_use_existing)
+            body = {
+              loginId: login_id,
+              phone:
+            }
+
+            body[:addToLoginIDs] = add_to_login_ids if add_to_login_ids
             body[:onMergeUseExisting] = on_merge_use_existing if on_merge_use_existing
 
             body

--- a/lib/descope/mixins/common.rb
+++ b/lib/descope/mixins/common.rb
@@ -81,6 +81,7 @@ module Descope
         VERIFY_ENCHANTEDLINK_AUTH_PATH = '/v1/auth/enchantedlink/verify'
         GET_SESSION_ENCHANTEDLINK_AUTH_PATH = '/v1/auth/enchantedlink/pending-session'
         UPDATE_USER_EMAIL_ENCHANTEDLINK_PATH = '/v1/auth/enchantedlink/update/email'
+        UPDATE_USER_PHONE_ENCHANTEDLINK_PATH = '/v1/auth/enchantedlink/update/phone'
 
         # oauth
         OAUTH_START_PATH = '/v1/auth/oauth/authorize'

--- a/spec/lib.descope/api/v1/auth/enchantedlink_spec.rb
+++ b/spec/lib.descope/api/v1/auth/enchantedlink_spec.rb
@@ -60,6 +60,48 @@ describe Descope::Api::V1::EnchantedLink do
         @instance.send(:validate_refresh_token_provided, { mfa: true, stepup: true }, '')
       end.to raise_error(Descope::AuthException, 'Missing refresh token for stepup/mfa')
     end
+
+    it 'is expected to respond to sign in with phone' do
+      expect(@instance).to respond_to(:enchanted_link_sign_in_with_phone)
+    end
+
+    it 'is expected to sign in with enchanted link via sms' do
+      request_params = {
+        loginId: '+1234567890',
+        redirectUrl: 'https://some-uri/sms',
+        loginOptions: {
+          stepup: false,
+          customClaims: { 'abc': '123' },
+          mfa: false,
+          ssoAppId: 'sso-id'
+        },
+        providerId: 'provider-id',
+        templateId: 'template-id'
+      }
+
+      expect(@instance).to receive(:post).with(
+        '/v1/auth/enchantedlink/signin/sms',
+        request_params,
+        {},
+        'refresh_token'
+      ).and_return({ 'linkId' => '1', 'pendingRef' => 'ref', 'maskedPhone' => '+1******890' })
+
+      res = @instance.enchanted_link_sign_in_with_phone(
+        login_id: '+1234567890',
+        uri: 'https://some-uri/sms',
+        login_options: {
+          stepup: false,
+          custom_claims: { 'abc': '123' },
+          mfa: false,
+          sso_app_id: 'sso-id'
+        },
+        provider_id: 'provider-id',
+        template_id: 'template-id',
+        refresh_token: 'refresh_token'
+      )
+
+      expect(res['maskedPhone']).to eq('+1******890')
+    end
   end
 
   context '.sign_up' do
@@ -87,6 +129,36 @@ describe Descope::Api::V1::EnchantedLink do
           user: { login_id: 'user1', email: 'dummy@dummy.com' }
         )
       end.not_to raise_error
+    end
+
+    it 'is expected to respond to sign up with phone' do
+      expect(@instance).to respond_to(:enchanted_link_sign_up_with_phone)
+    end
+
+    it 'is expected to sign up with enchanted link via sms' do
+      request_params = {
+        loginId: '+1234567890',
+        redirectUrl: 'https://some-uri/sms',
+        user: { loginId: 'user1', phone: '+1234567890' },
+        phone: '+1234567890',
+        providerId: 'provider-id',
+        templateId: 'template-id'
+      }
+
+      expect(@instance).to receive(:post).with(
+        '/v1/auth/enchantedlink/signup/sms',
+        request_params
+      ).and_return({ 'linkId' => '1', 'pendingRef' => 'ref', 'maskedPhone' => '+1******890' })
+
+      res = @instance.enchanted_link_sign_up_with_phone(
+        login_id: '+1234567890',
+        uri: 'https://some-uri/sms',
+        user: { login_id: 'user1', phone: '+1234567890' },
+        provider_id: 'provider-id',
+        template_id: 'template-id'
+      )
+
+      expect(res['maskedPhone']).to eq('+1******890')
     end
   end
 
@@ -124,6 +196,96 @@ describe Descope::Api::V1::EnchantedLink do
           }
         )
       end.not_to raise_error
+    end
+
+    it 'is expected to respond to sign up or in with phone' do
+      expect(@instance).to respond_to(:enchanted_link_sign_up_or_in_with_phone)
+    end
+
+    it 'is expected to sign up or in with enchanted link via sms' do
+      request_params = {
+        loginId: '+1234567890',
+        redirectUrl: 'https://some-uri/sms',
+        loginOptions: {
+          stepup: false,
+          customClaims: { 'abc': '123' },
+          mfa: false,
+          ssoAppId: 'sso-id'
+        },
+        providerId: 'provider-id',
+        templateId: 'template-id'
+      }
+
+      expect(@instance).to receive(:post).with(
+        '/v1/auth/enchantedlink/signup-in/sms',
+        request_params
+      ).and_return({ 'linkId' => '1', 'pendingRef' => 'ref', 'maskedPhone' => '+1******890' })
+
+      res = @instance.enchanted_link_sign_up_or_in_with_phone(
+        login_id: '+1234567890',
+        uri: 'https://some-uri/sms',
+        login_options: {
+          stepup: false,
+          custom_claims: { 'abc': '123' },
+          mfa: false,
+          sso_app_id: 'sso-id'
+        },
+        provider_id: 'provider-id',
+        template_id: 'template-id'
+      )
+
+      expect(res['maskedPhone']).to eq('+1******890')
+    end
+  end
+
+  context '.update_user_phone' do
+    it 'is expected to respond to update user phone' do
+      expect(@instance).to respond_to(:enchanted_link_update_user_phone)
+    end
+
+    it 'is expected to update user phone with enchanted link via sms' do
+      request_params = {
+        loginId: 'test',
+        phone: '+1234567890',
+        addToLoginIDs: true,
+        onMergeUseExisting: true,
+        redirectUrl: 'https://some-uri/sms',
+        providerId: 'provider-id',
+        templateId: 'template-id',
+        templateOptions: { 'abc': '123' }
+      }
+
+      expect(@instance).to receive(:post).with(
+        '/v1/auth/enchantedlink/update/phone/sms',
+        request_params,
+        {},
+        'refresh_token'
+      ).and_return({ 'linkId' => '1', 'pendingRef' => 'ref', 'maskedPhone' => '+1******890' })
+
+      res = @instance.enchanted_link_update_user_phone(
+        login_id: 'test',
+        phone: '+1234567890',
+        uri: 'https://some-uri/sms',
+        add_to_login_ids: true,
+        on_merge_use_existing: true,
+        provider_id: 'provider-id',
+        template_id: 'template-id',
+        template_options: { 'abc': '123' },
+        refresh_token: 'refresh_token'
+      )
+
+      expect(res['maskedPhone']).to eq('+1******890')
+    end
+
+    it 'is expected to raise an error on an invalid phone number' do
+      expect do
+        @instance.enchanted_link_update_user_phone(
+          login_id: 'test',
+          phone: 'not-a-phone',
+          uri: 'https://some-uri/sms',
+          refresh_token: 'refresh_token'
+        )
+      end.to raise_error(Descope::AuthException)
     end
   end
 


### PR DESCRIPTION
Adds Enchanted Link over SMS to descope-ruby-sdk.

- Four new phone methods on the enchanted link mixin.
- Additive only. Existing email methods unchanged.

Part of descope/etc#18315
